### PR TITLE
Add Immigration classifier option

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -283,6 +283,7 @@ export default function Home() {
               <option value="violent crime">Violent Crime</option>
               <option value="non-violent">Non-violent</option>
               <option value="unrelated">Unrelated</option>
+              <option value="immigration">Immigration</option>
             </select>
             <input
               type="number"

--- a/verkada_alerts_ui.html
+++ b/verkada_alerts_ui.html
@@ -58,6 +58,7 @@
           <option value="violent">Violent Crime</option>
           <option value="non-violent">Non-violent</option>
           <option value="unrelated">Unrelated</option>
+          <option value="immigration">Immigration</option>
         </select>
         <input type="number" step="0.01" placeholder="Min Score" class="border p-2 rounded w-24">
         <input type="number" step="0.01" placeholder="Max Score" class="border p-2 rounded w-24">


### PR DESCRIPTION
## Summary
- add `Immigration` to the classifier dropdown in the main app
- mirror the change in the static HTML page used for UI mocks

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa0b363dc8320a6c1a3f46baa6524